### PR TITLE
Added check for event callback type

### DIFF
--- a/elements/main.lua
+++ b/elements/main.lua
@@ -257,7 +257,7 @@ uie.default = {
             cb = self[funcOrID]
         end
 
-        if cb then
+        if uiu.isCallback(cb) then
             local rv = {cb(self, ...)}
             if #rv ~= 0 then
                 return table.unpack(rv)


### PR DESCRIPTION
Prevents crashes where the type is accidentally set to a bad value. In Lönn's case `visible` was set to true/false for windows.