### PR TITLE
Fix drag issue from text boxes in Lönn

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -399,7 +399,6 @@ function ui.mousereleased(x, y, button, istouch, presses)
             if dragging == ui.interactiveIterate(root:getChildAt(x, y)) then
                 ui.interactiveIterate(dragging, "onClick", x, y, button)
             end
-            dragging = false
         else
             ui.interactiveIterate(dragging, "onRelease", x, y, button, true)
         end


### PR DESCRIPTION
Can't see any other issues with this, the move events are not sent during a drag so not sure why mouse release should be either