### PR TITLE
Fixed cutoff that can happen when scrolling with my previous fix

### DIFF
--- a/elements/scroll.lua
+++ b/elements/scroll.lua
@@ -98,27 +98,35 @@ uie.add("scrollbox", {
             self.__dy = self.__dy + dy
         end
 
-        local x = -inner.x
-        local boxWidth = self.width
-        local innerWidth = inner.width
-        x = x + dx
-        if x < 0 then
-            x = 0
-        elseif innerWidth < x + boxWidth + wiggleroom then
-            x = innerWidth - boxWidth - wiggleroom
+        if self.handleX.isNeeded then
+            local x = -inner.x
+            local boxWidth = self.width
+            local innerWidth = inner.width
+            x = x + dx
+            if x < 0 then
+                x = 0
+            elseif innerWidth < x + boxWidth + wiggleroom then
+                x = innerWidth - boxWidth - wiggleroom
+            end
+            inner.x = uiu.round(-x)
+        else
+            inner.x = 0
         end
-        inner.x = uiu.round(-x)
 
-        local y = -inner.y
-        local boxHeight = self.height
-        local innerHeight = inner.height
-        y = y + dy
-        if y < 0 then
-            y = 0
-        elseif innerHeight < y + boxHeight + wiggleroom then
-            y = innerHeight - boxHeight - wiggleroom
+        if self.handleY.isNeeded then
+            local y = -inner.y
+            local boxHeight = self.height
+            local innerHeight = inner.height
+            y = y + dy
+            if y < 0 then
+                y = 0
+            elseif innerHeight < y + boxHeight then
+                y = innerHeight - boxHeight
+            end
+            inner.y = uiu.round(-y)
+        else
+            inner.y = 0
         end
-        inner.y = uiu.round(-y)
 
         self:afterScroll()
     end


### PR DESCRIPTION
Turns out that wiggle room was important after all, and I just didn't see the mistake in my testing up until now
New approach is to use the isNeeded attribute on the scrollhandle to see if we are scrollable instead
This keeps a proper clamping on the scroll value of the field, and lets the handle figure out if the wiggle room is important