### PR TITLE
Added very basic off screen canvas culling

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -28,6 +28,7 @@ local ui = {
         eventProxies = false,
         inspector = "f12",
         megacanvas = false,
+        clearOffScreenCanvas = false,
     },
 
     eventProxyCache = {},


### PR DESCRIPTION
Current offscreen canvases will never get cleared
Just a simple solution to fix some VRAM "leaks" in Lönn
Preferably this is replaced with "lazy lists" in the future