### PR TITLE
Feature/textfield ctrl movement

### DIFF
--- a/elements/input.lua
+++ b/elements/input.lua
@@ -542,14 +542,18 @@ uie.add("field", {
             if self:hasSelection() then
                 self:deleteSelectedText()
             else
+                local from = index
                 if index == 0 then
                     return
                 elseif index == 1 then
                     self.text = text:sub(utf8.offset(text, index + 1))
                 else
-                    self.text = text:sub(1, utf8.offset(text, index) - 1) .. text:sub(utf8.offset(text, index + 1))
+                    if hotkeyModifierHeld then
+                        from = uiu.findWordBorder(text, index - 1, -1)
+                    end
+                    self.text = text:sub(1, utf8.offset(text, from) - 1) .. text:sub(utf8.offset(text, index + 1))
                 end
-                self.index = math.max(0, index - 1)
+                self.index = math.max(0, from - 1)
             end
             self.blinkTime = 0
             self:repaint()
@@ -558,13 +562,17 @@ uie.add("field", {
             if self:hasSelection() then
                 self:deleteSelectedText()
             else
+                local from = index + 1
                 if index == utf8.len(text) then
                     return
                 end
+                if hotkeyModifierHeld then
+                    from = uiu.findWordBorder(text, index + 2, 1)
+                end
                 if index == 0 then
-                    self.text = text:sub(utf8.offset(text, index + 2))
+                    self.text = text:sub(utf8.offset(text, from + 1))
                 else
-                    self.text = text:sub(1, utf8.offset(text, index + 1) - 1) .. text:sub(utf8.offset(text, index + 2))
+                    self.text = text:sub(1, utf8.offset(text, index + 1) - 1) .. text:sub(utf8.offset(text, from + 1))
                 end
                 self.index = math.min(utf8.len(text), index)
             end

--- a/elements/input.lua
+++ b/elements/input.lua
@@ -572,7 +572,11 @@ uie.add("field", {
             self:repaint()
 
         elseif key == "left" then
-            local newIndex = math.max(0, index - 1)
+            local targetIndex = index - 1
+            if hotkeyModifierHeld then
+                targetIndex = uiu.findWordBorder(text, index - 1, -1) - 1
+            end
+            local newIndex = math.max(0, targetIndex)
             local _, clearedSelection, start, _ = self:setCursorIndex(newIndex, selectionModifierHeld)
             if clearedSelection then
                 -- Jump cursor to start of the selection
@@ -587,7 +591,11 @@ uie.add("field", {
             self:repaint()
 
         elseif key == "right" then
-            local newIndex = math.min(utf8.len(text), index + 1)
+            local targetIndex = index + 1
+            if hotkeyModifierHeld then
+                targetIndex = uiu.findWordBorder(text, index + 2, 1)
+            end
+            local newIndex = math.min(utf8.len(text), targetIndex)
             local _, clearedSelection, _, stop = self:setCursorIndex(newIndex, selectionModifierHeld)
             if clearedSelection then
                 -- Jump cursor to end of the selection

--- a/utils.lua
+++ b/utils.lua
@@ -810,6 +810,10 @@ function uiu.isWordCharacter(char, allowUnderscore)
         return true
     end
 
+    if char == " " then
+        return false
+    end
+
     -- Punctuation characters
     if string.match(char, "%p") then
         return false


### PR DESCRIPTION
Adds ctrl movement/deletion to textfields
Ctrl + left: Jump to start of word
Ctrl + right: Jump to end of word
Ctrl + backspace: Delete until start of word
Ctrl + delete: Delete until end of word

Fixes ` ` (space) not being recognized as a word splitting character.